### PR TITLE
update kill storage and bug fixes

### DIFF
--- a/pallets/afloat/src/functions.rs
+++ b/pallets/afloat/src/functions.rs
@@ -859,11 +859,14 @@ impl<T: Config> Pallet<T> {
     Ok(())
   }
 
-  pub fn do_cancel_offer(order_id: StorageId) -> DispatchResult {
+  pub fn do_cancel_offer(who: T::AccountId, order_id: StorageId) -> DispatchResult {
 	// ensure offer exists
     ensure!(<AfloatOffers<T>>::contains_key(order_id), Error::<T>::OfferNotFound);
     //get offer details
     let offer = <AfloatOffers<T>>::get(order_id).unwrap();
+	let is_admin_or_owner = Self::is_admin_or_owner(who.clone())?;
+    ensure!(is_admin_or_owner || offer.creator_id == who, Error::<T>::Unauthorized);
+
 	match offer.status {
 		OfferStatus::CREATED => {
 			<AfloatOffers<T>>::try_mutate(order_id, |offer| -> DispatchResult {

--- a/pallets/afloat/src/lib.rs
+++ b/pallets/afloat/src/lib.rs
@@ -255,11 +255,40 @@ pub mod pallet {
 
     #[pallet::call_index(1)]
     #[pallet::weight(Weight::from_parts(10_000,0) + T::DbWeight::get().reads_writes(1,1))]
-    pub fn kill_storage(origin: OriginFor<T>) -> DispatchResult {
+    pub fn kill_storage(origin: OriginFor<T>, args: KillStorageArgs) -> DispatchResult {
       // ensure sudo origin
       T::RemoveOrigin::ensure_origin(origin.clone())?;
-      Self::do_delete_all_users()?;
-      Ok(())
+	  match args {
+		KillStorageArgs::All => {
+		  Self::do_delete_all_users()?;
+		  <AfloatMarketPlaceId<T>>::kill();
+		  <AfloatCollectionId<T>>::kill();
+		  <AfloatAssetId<T>>::kill();
+		  let _ = <AfloatOffers<T>>::clear(1000, None);
+		  let _ = <AfloatTransactions<T>>::clear(1000, None);
+		},
+		KillStorageArgs::UserInfo => {
+		  Self::do_delete_all_users()?;
+		}
+		KillStorageArgs::AfloatMarketPlaceId => {
+		  <AfloatMarketPlaceId<T>>::kill();
+		},
+		KillStorageArgs::AfloatCollectionId => {
+		  <AfloatCollectionId<T>>::kill();
+		},
+		KillStorageArgs::AfloatAssetId => {
+		  <AfloatAssetId<T>>::kill();
+		},
+		KillStorageArgs::AfloatOffers => {
+		  let _ = <AfloatOffers<T>>::clear(1000, None);
+		},
+		KillStorageArgs::AfloatTransactions => {
+		  let _ = <AfloatTransactions<T>>::clear(1000, None);
+		},
+
+	  }
+
+	  Ok(())
     }
 
     #[pallet::call_index(2)]

--- a/pallets/afloat/src/lib.rs
+++ b/pallets/afloat/src/lib.rs
@@ -433,9 +433,7 @@ pub mod pallet {
     #[pallet::weight(Weight::from_parts(10_000,0) + T::DbWeight::get().reads_writes(1,1))]
     pub fn cancel_offer(origin: OriginFor<T>, order_id: StorageId) -> DispatchResult {
       let who = ensure_signed(origin.clone())?;
-      let is_admin_or_owner = Self::is_admin_or_owner(who.clone())?;
-      ensure!(is_admin_or_owner, Error::<T>::Unauthorized);
-	  Self::do_cancel_offer(order_id)
+	  Self::do_cancel_offer(who, order_id)
     }
   }
 }

--- a/pallets/afloat/src/types.rs
+++ b/pallets/afloat/src/types.rs
@@ -161,6 +161,17 @@ pub enum CreateOfferArgs<T: Config> {
   },
 }
 
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebugNoBound, TypeInfo)]
+pub enum KillStorageArgs {
+  All,
+  UserInfo,
+  AfloatMarketPlaceId,
+  AfloatCollectionId,
+  AfloatAssetId,
+  AfloatOffers,
+  AfloatTransactions,
+}
+
 // ! Transaction structures
 
 #[derive(CloneNoBound, Encode, Decode, RuntimeDebugNoBound, TypeInfo, MaxEncodedLen, PartialEq)]


### PR DESCRIPTION
- Added a parameter to do_cancel_offer to check if the user is authorized [functions.rs](https://github.com/hashed-io/hashed-pallets/blob/35e5ba01a56d006316e4a694442f59ffd6a27e70/pallets/afloat/src/functions.rs)
- Updated cancel_offer to include the new parameter [lib.rs](https://github.com/hashed-io/hashed-pallets/blob/35e5ba01a56d006316e4a694442f59ffd6a27e70/pallets/afloat/src/lib.rs)
- Removed the check for authorization in cancel_offer [lib.rs](https://github.com/hashed-io/hashed-pallets/blob/35e5ba01a56d006316e4a694442f59ffd6a27e70/pallets/afloat/src/lib.rs)

- Added several new features to the kill_storage and cancel_offer functions
- Added an argument to kill_storage to specify which storage to clear
- Added a parameter to do_cancel_offer to check if the user is authorized
- Updated the cancel_offer function to only allow the offer owner to cancel the offer
- Added a new KillStorageArgs enum to specify which storage to clear