### PR TITLE
add missing permissions in afloat

### DIFF
--- a/pallets/afloat/src/functions.rs
+++ b/pallets/afloat/src/functions.rs
@@ -856,6 +856,8 @@ impl<T: Config> Pallet<T> {
 
 		Self::give_role_to_user(user_address.clone(), AfloatRole::Admin)?;
 
+		Self::do_add_account_to_afloat_frunique(user_address.clone(), FruniqueRole::Admin)?;
+
 		Self::deposit_event(Event::AdminAdded(authority, user_address));
 		Ok(())
 	}

--- a/pallets/afloat/src/lib.rs
+++ b/pallets/afloat/src/lib.rs
@@ -223,6 +223,14 @@ pub mod pallet {
 					Self::do_setup_roles(creator, admin)?;
 					Ok(())
 				},
+				InitialSetupArgs::AddAfloatRole { who, role } => {
+					Self::give_role_to_user(who, role)?;
+					Ok(())
+				},
+				InitialSetupArgs::AddFruniqueRole { who, role } => {
+					Self::do_add_account_to_afloat_frunique(who, FruniqueRole::Admin)?;
+					Ok(())
+				},
 			}
 		}
 

--- a/pallets/afloat/src/lib.rs
+++ b/pallets/afloat/src/lib.rs
@@ -228,7 +228,7 @@ pub mod pallet {
 					Ok(())
 				},
 				InitialSetupArgs::AddFruniqueRole { who, role } => {
-					Self::do_add_account_to_afloat_frunique(who, FruniqueRole::Admin)?;
+					Self::do_add_account_to_afloat_frunique(who, role)?;
 					Ok(())
 				},
 			}

--- a/pallets/afloat/src/types.rs
+++ b/pallets/afloat/src/types.rs
@@ -1,5 +1,6 @@
 use super::*;
 use frame_support::{pallet_prelude::*, sp_io::hashing::blake2_256};
+use pallet_fruniques::types::FruniqueRole;
 use sp_runtime::sp_std::vec::Vec;
 
 pub type ShortString = BoundedVec<u8, ConstU32<55>>;
@@ -198,7 +199,7 @@ pub enum InitialSetupArgs<T: Config> {
 	All { creator: T::AccountId, admin: T::AccountId, asset: CreateAsset<T> },
 	Roles { creator: T::AccountId, admin: T::AccountId },
 	AddAfloatRole { who: T::AccountId, role: AfloatRole },
-	AddFruniqueRole { who: T::AccountId, role: AfloatRole },
+	AddFruniqueRole { who: T::AccountId, role: FruniqueRole },
 }
 
 // ! Transaction structures

--- a/pallets/afloat/src/types.rs
+++ b/pallets/afloat/src/types.rs
@@ -197,6 +197,8 @@ pub enum CreateAsset<T: Config> {
 pub enum InitialSetupArgs<T: Config> {
 	All { creator: T::AccountId, admin: T::AccountId, asset: CreateAsset<T> },
 	Roles { creator: T::AccountId, admin: T::AccountId },
+	AddAfloatRole { who: T::AccountId, role: AfloatRole },
+	AddFruniqueRole { who: T::AccountId, role: AfloatRole },
 }
 
 // ! Transaction structures

--- a/pallets/fruniques/src/lib.rs
+++ b/pallets/fruniques/src/lib.rs
@@ -509,19 +509,5 @@ pub mod pallet {
 			T::Rbac::remove_pallet_storage(Self::pallet_id())?;
 			Ok(())
 		}
-
-		#[pallet::call_index(10)]
-		#[pallet::weight(Weight::from_parts(10_000,0) + T::DbWeight::get().writes(1))]
-		pub fn spam_spawning(
-			origin: OriginFor<T>,
-			class_id: T::CollectionId,
-			instances: u32,
-		) -> DispatchResult {
-			let _ = ensure_signed(origin)?;
-			// for instance in instances {
-			// 	let _ = Self::mint(instance, class_id, None, None, None, None, None, None, None)?;
-			// }
-			Ok(())
-		}
 	}
 }


### PR DESCRIPTION
PR summary so far:

  * Added functions to add a user to an AfloatRole or FruniqueRole
  * Added `AddAfloatRole` and `AddFruniqueRole` variants to the `InitialSetupArgs` enum
  * Changed the parameter type for `AddFruniqueRole` from `AfloatRole` to `FruniqueRole`
  * Remove unused extrinsic `spam_spawning`