### PR TITLE
Fix build issues polkadotv1

### DIFF
--- a/pallets/bitcoin-vaults/src/functions.rs
+++ b/pallets/bitcoin-vaults/src/functions.rs
@@ -474,6 +474,7 @@ impl<T: Config> Pallet<T> {
 			fraction: 0,
 			fraction_length: 0,
 			exponent: 0,
+			negative: false,
 		};
 		body.push(("threshold".chars().collect::<Vec<char>>(), JsonValue::Number(threshold)));
 		let vault_signers = vault.cosigners.clone().to_vec();
@@ -573,16 +574,18 @@ impl<T: Config> Pallet<T> {
 		let vault = <Vaults<T>>::get(proposal.vault_id.clone())
 			.ok_or(Self::build_offchain_err(false, "Vault not found"))?;
 		let amount = NumberValue {
-			integer: proposal.amount.clone() as i64,
+			integer: proposal.amount.clone() as u64,
 			fraction: 0,
 			fraction_length: 0,
 			exponent: 0,
+			negative: false,
 		};
 		let fee = NumberValue {
 			integer: proposal.fee_sat_per_vb.clone().into(),
 			fraction: 0,
 			fraction_length: 0,
 			exponent: 0,
+			negative: false,
 		};
 		let to_address = str::from_utf8(proposal.to_address.as_slice())
 			.map_err(|_| {

--- a/pallets/bitcoin-vaults/src/lib.rs
+++ b/pallets/bitcoin-vaults/src/lib.rs
@@ -39,20 +39,24 @@ pub mod pallet {
 	/* --- Genesis Structs Section --- */
 
 	#[pallet::genesis_config]
-	#[derive(Default)]
-	pub struct GenesisConfig {
+	pub struct GenesisConfig<T: Config> {
 		pub bdk_services_url: Vec<u8>,
+		#[serde(skip)]
+		pub _config: sp_std::marker::PhantomData<T>,
 	}
 
 	#[cfg(feature = "std")]
-	impl Default for GenesisConfig {
+	impl<T: Config> Default for GenesisConfig<T> {
 		fn default() -> Self {
-			Self { bdk_services_url: b"https://bdk.hashed.systems".encode() }
+			Self {
+				bdk_services_url: b"https://bdk.hashed.systems".encode(),
+				_config: Default::default(),
+			}
 		}
 	}
 
 	#[pallet::genesis_build]
-	impl<T: Config> GenesisBuild<T> for GenesisConfig {
+	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
 		fn build(&self) {
 			<BDKServicesURL<T>>::put(
 				BoundedVec::<u8, ConstU32<32>>::try_from(self.bdk_services_url.clone())
@@ -275,7 +279,7 @@ pub mod pallet {
 		/// Note that it's not guaranteed for offchain workers to run on EVERY block, there might
 		/// be cases where some blocks are skipped, or for some the worker runs twice (re-orgs),
 		/// so the code should be able to handle that.
-		fn offchain_worker(_block_number: T::BlockNumber) {
+		fn offchain_worker(_block_number: BlockNumberFor<T>) {
 			// check if the node has an account available, the offchain worker can't submit
 			// transactions without it
 			let signer = Signer::<T, T::AuthorityId>::any_account();

--- a/pallets/bitcoin-vaults/src/mock.rs
+++ b/pallets/bitcoin-vaults/src/mock.rs
@@ -8,39 +8,40 @@ use frame_system::EnsureRoot;
 use pallet_balances;
 use sp_core::H256;
 //use sp_keystore::{testing::KeyStore, KeystoreExt, SyncCryptoStore};
+use sp_runtime::BuildStorage;
 use sp_runtime::{
-	testing::{Header, TestXt},
+	testing::TestXt,
 	traits::{BlakeTwo256, Extrinsic as ExtrinsicT, IdentifyAccount, IdentityLookup, Verify},
 	//RuntimeAppPublic,
 };
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 //use sp_runtime::generic::SignedPayload;
 use sp_core::sr25519::Signature;
 
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
-	pub enum Test where
-		Block = Block,
-		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+	pub enum Test
 	{
-		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
 		BitcoinVaults: pallet_bitcoin_vaults::{Pallet, Call, Storage, Event<T>, ValidateUnsigned},
 		Balances: pallet_balances::{Pallet, Call, Storage, Event<T>},
 	}
 );
 
 impl pallet_balances::Config for Test {
-	type MaxLocks = ();
-	type MaxReserves = ();
-	type ReserveIdentifier = [u8; 8];
 	type Balance = u64;
-	type RuntimeEvent = RuntimeEvent;
 	type DustRemoval = ();
+	type RuntimeEvent = RuntimeEvent;
 	type ExistentialDeposit = ConstU64<1>;
 	type AccountStore = System;
 	type WeightInfo = ();
+	type MaxLocks = ();
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 8];
+	type RuntimeHoldReason = ();
+	type FreezeIdentifier = ();
+	type MaxHolds = ();
+	type MaxFreezes = ();
 }
 
 parameter_types! {
@@ -106,14 +107,13 @@ impl frame_system::Config for Test {
 	type BlockWeights = ();
 	type BlockLength = ();
 	type RuntimeOrigin = RuntimeOrigin;
-	type Index = u64;
-	type BlockNumber = u64;
 	type Hash = H256;
 	type RuntimeCall = RuntimeCall;
+	type Nonce = u64;
 	type Hashing = BlakeTwo256;
 	type AccountId = sp_core::sr25519::Public;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Block = Block;
 	type RuntimeEvent = RuntimeEvent;
 	type BlockHashCount = ConstU64<250>;
 	type DbWeight = ();
@@ -134,7 +134,7 @@ pub fn test_pub(n: u8) -> sp_core::sr25519::Public {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 	pallet_balances::GenesisConfig::<Test> {
 		balances: vec![(test_pub(1), 10000), (test_pub(2), 1000), (test_pub(3), 1000)],
 	}

--- a/pallets/confidential-docs/src/mock.rs
+++ b/pallets/confidential-docs/src/mock.rs
@@ -1,24 +1,19 @@
 use crate as pallet_confidential_docs;
-use frame_support::parameter_types;
+use frame_support::{construct_runtime, parameter_types};
 use frame_system as system;
 use frame_system::EnsureRoot;
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
 };
-
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 // Configure a mock runtime to test the pallet.
-frame_support::construct_runtime!(
-	pub enum Test where
-		Block = Block,
-		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+construct_runtime!(
+	pub enum Test
 	{
-		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
 		ConfidentialDocs: pallet_confidential_docs::{Pallet, Call, Storage, Event<T>},
 	}
 );
@@ -35,13 +30,12 @@ impl system::Config for Test {
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
-	type Index = u64;
-	type BlockNumber = u64;
+	type Nonce = u64;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Block = Block;
 	type RuntimeEvent = RuntimeEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
@@ -85,7 +79,7 @@ impl pallet_confidential_docs::Config for Test {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let storage = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	let storage = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 	let mut ext: sp_io::TestExternalities = storage.into();
 	ext.execute_with(|| System::set_block_number(1));
 	ext

--- a/pallets/fruniques/src/functions.rs
+++ b/pallets/fruniques/src/functions.rs
@@ -68,7 +68,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn admin_of(class_id: &T::CollectionId, instance_id: &T::ItemId) -> Option<T::AccountId> {
-		pallet_uniques::Pallet::<T>::owner(*class_id, *instance_id)
+		pallet_uniques::Pallet::<T>::owner(class_id.clone(), *instance_id)
 	}
 
 	pub fn is_frozen(collection_id: &T::CollectionId, instance_id: &T::ItemId) -> bool {
@@ -79,14 +79,14 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn collection_exists(class_id: &T::CollectionId) -> bool {
-		if let Some(_owner) = pallet_uniques::Pallet::<T>::collection_owner(*class_id) {
+		if let Some(_owner) = pallet_uniques::Pallet::<T>::collection_owner(class_id.clone()) {
 			return true
 		}
 		false
 	}
 
 	pub fn instance_exists(class_id: &T::CollectionId, instance_id: &T::ItemId) -> bool {
-		if let Some(_owner) = pallet_uniques::Pallet::<T>::owner(*class_id, *instance_id) {
+		if let Some(_owner) = pallet_uniques::Pallet::<T>::owner(class_id.clone(), *instance_id) {
 			return true
 		}
 		false
@@ -164,7 +164,7 @@ impl<T: Config> Pallet<T> {
 	) -> DispatchResult {
 		pallet_uniques::Pallet::<T>::set_attribute(
 			origin,
-			*class_id.clone(),
+			class_id.clone(),
 			Some(instance_id),
 			key,
 			value,
@@ -247,7 +247,7 @@ impl<T: Config> Pallet<T> {
 
 		pallet_uniques::Pallet::<T>::burn(
 			origin,
-			*class_id,
+			class_id.clone(),
 			instance_id,
 			Some(Self::account_id_to_lookup_source(&admin.unwrap())),
 		)?;
@@ -372,7 +372,7 @@ impl<T: Config> Pallet<T> {
 		let child_percentage: Permill = parent_info.parent_weight * frunique_parent.weight;
 
 		let parent_data: ParentInfo<T> = ParentInfo {
-			collection_id: parent_info.collection_id,
+			collection_id: parent_info.collection_id.clone(),
 			parent_id: parent_info.parent_id,
 			parent_weight: child_percentage,
 			is_hierarchical: parent_info.is_hierarchical,
@@ -400,7 +400,7 @@ impl<T: Config> Pallet<T> {
 		};
 
 		<FruniqueInfo<T>>::try_mutate::<_, _, _, DispatchError, _>(
-			parent_info.collection_id,
+			parent_info.collection_id.clone(),
 			parent_info.parent_id,
 			|frunique_data| -> DispatchResult {
 				let frunique = frunique_data.as_mut().ok_or(Error::<T>::FruniqueNotFound)?;

--- a/pallets/fruniques/src/mock.rs
+++ b/pallets/fruniques/src/mock.rs
@@ -2,22 +2,18 @@ use crate as pallet_fruniques;
 use frame_support::{construct_runtime, parameter_types, traits::AsEnsureOriginWithArg};
 use frame_system::{EnsureRoot, EnsureSigned};
 use pallet_balances;
-use sp_core::H256;
+use sp_core::{ConstU64, H256};
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 construct_runtime!(
-  pub enum Test where
-	Block = Block,
-	NodeBlock = Block,
-	UncheckedExtrinsic = UncheckedExtrinsic,
+  pub enum Test
   {
-	System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+	System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
 	Uniques: pallet_uniques::{Pallet, Call, Storage, Event<T>},
 	Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 	Fruniques: pallet_fruniques::{Pallet, Call, Storage, Event<T>},
@@ -36,13 +32,12 @@ impl frame_system::Config for Test {
 	type BlockLength = ();
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
-	type Index = u64;
-	type BlockNumber = u64;
+	type Nonce = u64;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Block = Block;
 	type RuntimeEvent = RuntimeEvent;
 	type BlockHashCount = BlockHashCount;
 	type DbWeight = ();
@@ -97,21 +92,20 @@ impl pallet_uniques::Config for Test {
 	type Locker = ();
 }
 
-parameter_types! {
-  pub const ExistentialDeposit: u64 = 1;
-  pub const MaxReserves: u32 = 50;
-}
-
 impl pallet_balances::Config for Test {
 	type Balance = u64;
 	type DustRemoval = ();
 	type RuntimeEvent = RuntimeEvent;
-	type ExistentialDeposit = ExistentialDeposit;
+	type ExistentialDeposit = ConstU64<1>;
 	type AccountStore = System;
 	type WeightInfo = ();
 	type MaxLocks = ();
-	type MaxReserves = MaxReserves;
+	type MaxReserves = ();
 	type ReserveIdentifier = [u8; 8];
+	type RuntimeHoldReason = ();
+	type FreezeIdentifier = ();
+	type MaxHolds = ();
+	type MaxFreezes = ();
 }
 
 parameter_types! {
@@ -142,7 +136,7 @@ impl pallet_rbac::Config for Test {
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let balance_amount = 1_000_000 as u64;
-	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 	pallet_balances::GenesisConfig::<Test> {
 		balances: vec![(1, balance_amount), (2, balance_amount), (3, balance_amount)],
 	}

--- a/pallets/fruniques/src/tests.rs
+++ b/pallets/fruniques/src/tests.rs
@@ -1,9 +1,8 @@
-use crate::{mock::*, Error};
+use crate::{mock::*, types::ParentInfoCall, Error};
 use codec::Encode;
 use core::convert::TryFrom;
-
-use crate::types::ParentInfoCall;
 use frame_support::{assert_noop, assert_ok, BoundedVec};
+use sp_runtime::BuildStorage;
 pub struct ExtBuilder;
 
 // helper function to set BoundedVec
@@ -21,7 +20,7 @@ impl Default for ExtBuilder {
 
 impl ExtBuilder {
 	pub fn build(self) -> sp_io::TestExternalities {
-		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+		let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 		pallet_balances::GenesisConfig::<Test> {
 			balances: vec![(1, 100), (2, 20), (3, 30), (4, 40), (5, 50), (6, 60)],
 		}

--- a/pallets/fund-admin-records/src/mock.rs
+++ b/pallets/fund-admin-records/src/mock.rs
@@ -3,22 +3,18 @@ use frame_support::parameter_types;
 use frame_system as system;
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 use frame_system::EnsureRoot;
 
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
-	pub enum Test where
-		Block = Block,
-		NodeBlock = Block,
-		UncheckedExtrinsic = UncheckedExtrinsic,
+	pub enum Test
 	{
-		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
 		FundAdminRecords: pallet_fund_admin_records::{Pallet, Call, Storage, Event<T>},
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 	}
@@ -36,13 +32,12 @@ impl system::Config for Test {
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
-	type Index = u64;
-	type BlockNumber = u64;
+	type Nonce = u64;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Block = Block;
 	type RuntimeEvent = RuntimeEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
@@ -79,5 +74,5 @@ impl pallet_timestamp::Config for Test {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
+	system::GenesisConfig::<Test>::default().build_storage().unwrap().into()
 }

--- a/pallets/fund-admin/src/mock.rs
+++ b/pallets/fund-admin/src/mock.rs
@@ -1,24 +1,20 @@
 use crate as pallet_fund_admin;
 use frame_support::parameter_types;
 use frame_system as system;
-use sp_core::H256;
+use sp_core::{ConstU64, H256};
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
 };
 
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 use frame_system::EnsureRoot;
 
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
-  pub enum Test where
-	Block = Block,
-	NodeBlock = Block,
-	UncheckedExtrinsic = UncheckedExtrinsic,
+  pub enum Test
   {
-	System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+	System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
 	FundAdmin: pallet_fund_admin::{Pallet, Call, Storage, Event<T>},
 	Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
 	RBAC: pallet_rbac::{Pallet, Call, Storage, Event<T>},
@@ -26,21 +22,20 @@ frame_support::construct_runtime!(
   }
 );
 
-parameter_types! {
-  pub const ExistentialDeposit: u64 = 1;
-  pub const MaxReserves: u32 = 50;
-}
-
 impl pallet_balances::Config for Test {
 	type Balance = u64;
 	type DustRemoval = ();
 	type RuntimeEvent = RuntimeEvent;
-	type ExistentialDeposit = ExistentialDeposit;
+	type ExistentialDeposit = ConstU64<1>;
 	type AccountStore = System;
 	type WeightInfo = ();
 	type MaxLocks = ();
-	type MaxReserves = MaxReserves;
+	type MaxReserves = ();
 	type ReserveIdentifier = [u8; 8];
+	type RuntimeHoldReason = ();
+	type FreezeIdentifier = ();
+	type MaxHolds = ();
+	type MaxFreezes = ();
 }
 
 parameter_types! {
@@ -55,13 +50,12 @@ impl system::Config for Test {
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
-	type Index = u64;
-	type BlockNumber = u64;
+	type Nonce = u64;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Block = Block;
 	type RuntimeEvent = RuntimeEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
@@ -162,7 +156,7 @@ impl pallet_rbac::Config for Test {
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let balance_amount = InitialAdminBalance::get();
-	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
 	pallet_balances::GenesisConfig::<Test> { balances: vec![(1, balance_amount)] }
 		.assimilate_storage(&mut t)
 		.expect("assimilate_storage failed");

--- a/pallets/gated-marketplace/src/mock.rs
+++ b/pallets/gated-marketplace/src/mock.rs
@@ -1,37 +1,29 @@
 use crate as pallet_gated_marketplace;
 use frame_support::{
 	parameter_types,
-	traits::{AsEnsureOriginWithArg, ConstU32, ConstU64, GenesisBuild},
+	traits::{AsEnsureOriginWithArg, ConstU32, ConstU64},
 };
 use frame_system as system;
 use sp_core::H256;
-use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-};
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 /// Balance of an account.
 pub type Balance = u128;
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 use frame_system::EnsureRoot;
-use pallet_mapped_assets::DefaultCallback;
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{AccountIdLookup, Block as BlockT, IdentifyAccount, NumberFor, Verify},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	AccountId32, ApplyExtrinsicResult, MultiSignature, Percent,
+	AccountId32, ApplyExtrinsicResult, BuildStorage, MultiSignature, Percent,
 };
 use system::EnsureSigned;
 type AccountId = u64;
 type AssetId = u32;
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
-  pub enum Test where
-	Block = Block,
-	NodeBlock = Block,
-	UncheckedExtrinsic = UncheckedExtrinsic,
+  pub enum Test
   {
-	System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+	System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
 	GatedMarketplace: pallet_gated_marketplace::{Pallet, Call, Storage, Event<T>},
 	Uniques: pallet_uniques::{Pallet, Call, Storage, Event<T>},
 	Fruniques: pallet_fruniques::{Pallet, Call, Storage, Event<T>},
@@ -54,13 +46,12 @@ impl system::Config for Test {
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
-	type Index = u64;
-	type BlockNumber = u64;
+	type Nonce = u64;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Block = Block;
 	type RuntimeEvent = RuntimeEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
@@ -153,21 +144,20 @@ impl pallet_uniques::Config for Test {
 	type Locker = ();
 }
 
-parameter_types! {
-  pub const ExistentialDeposit: u64 = 1;
-  pub const MaxReserves: u32 = 50;
-}
-
 impl pallet_balances::Config for Test {
 	type Balance = u64;
 	type DustRemoval = ();
 	type RuntimeEvent = RuntimeEvent;
-	type ExistentialDeposit = ExistentialDeposit;
+	type ExistentialDeposit = ConstU64<1>;
 	type AccountStore = System;
 	type WeightInfo = ();
 	type MaxLocks = ();
-	type MaxReserves = MaxReserves;
+	type MaxReserves = ();
 	type ReserveIdentifier = [u8; 8];
+	type RuntimeHoldReason = ();
+	type FreezeIdentifier = ();
+	type MaxHolds = ();
+	type MaxFreezes = ();
 }
 
 parameter_types! {
@@ -195,7 +185,7 @@ impl pallet_rbac::Config for Test {
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	// TODO: get initial conf?
 	let mut t: sp_io::TestExternalities =
-		frame_system::GenesisConfig::default().build_storage::<Test>().unwrap().into();
+		frame_system::GenesisConfig::<Test>::default().build_storage().unwrap().into();
 	t.execute_with(|| {
 		GatedMarketplace::do_initial_setup()
 			.expect("Error on GatedMarketplace configuring initial setup");
@@ -217,19 +207,15 @@ parameter_types! {
   pub const RemoveItemsLimit: u32 = 1000;
 }
 
-pub trait AssetsCallback<AssetId, AccountId> {
-	/// Indicates that asset with `id` was successfully created by the `owner`
-	fn created(_id: &AssetId, _owner: &AccountId) {}
-
-	/// Indicates that asset with `id` has just been destroyed
-	fn destroyed(_id: &AssetId) {}
-}
-
 pub struct AssetsCallbackHandle;
 impl pallet_mapped_assets::AssetsCallback<u32, u64> for AssetsCallbackHandle {
-	fn created(_id: &AssetId, _owner: &u64) {}
+	fn created(_id: &AssetId, _owner: &u64) -> Result<(), ()> {
+		Ok(())
+	}
 
-	fn destroyed(_id: &AssetId) {}
+	fn destroyed(_id: &AssetId) -> Result<(), ()> {
+		Ok(())
+	}
 }
 
 impl pallet_mapped_assets::Config for Test {
@@ -251,6 +237,5 @@ impl pallet_mapped_assets::Config for Test {
 	type CallbackHandle = AssetsCallbackHandle;
 	type Extra = ();
 	type RemoveItemsLimit = ConstU32<5>;
-	type MaxReserves = MaxReserves;
-	type ReserveIdentifier = u32;
+	type Rbac = RBAC;
 }

--- a/pallets/mapped-assets/src/lib.rs
+++ b/pallets/mapped-assets/src/lib.rs
@@ -178,7 +178,7 @@ use frame_support::{
 use frame_system::Config as SystemConfig;
 
 pub use pallet::*;
-// use pallet_rbac::types::RoleBasedAccessControl;
+use pallet_rbac::types::RoleBasedAccessControl;
 pub use weights::WeightInfo;
 
 type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
@@ -234,7 +234,7 @@ pub mod pallet {
 		type RuntimeEvent: From<Event<Self, I>>
 			+ IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
-		// type Rbac: RoleBasedAccessControl<Self::AccountId>;
+		type Rbac: RoleBasedAccessControl<Self::AccountId>;
 		/// The units in which we record balances.
 		type Balance: Member
 			+ Parameter
@@ -382,7 +382,7 @@ pub mod pallet {
 	}
 
 	#[pallet::genesis_build]
-	impl<T: Config<I>, I: 'static> GenesisBuild<T, I> for GenesisConfig<T, I> {
+	impl<T: Config<I>, I: 'static> BuildGenesisConfig for GenesisConfig<T, I> {
 		fn build(&self) {
 			for (id, owner, is_sufficient, min_balance) in &self.assets {
 				assert!(!Asset::<T, I>::contains_key(id), "Asset id already in use");

--- a/pallets/mapped-assets/src/mock.rs
+++ b/pallets/mapped-assets/src/mock.rs
@@ -176,6 +176,7 @@ impl Config for Test {
 	type RemoveItemsLimit = ConstU32<5>;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
+	type Rbac = RBAC;
 }
 
 use std::collections::HashMap;

--- a/pallets/mapped-assets/src/tests.rs
+++ b/pallets/mapped-assets/src/tests.rs
@@ -159,7 +159,7 @@ fn approval_lifecycle_works() {
 		// can't approve non-existent token
 		assert_noop!(
 			Assets::approve_transfer(RuntimeOrigin::signed(1), 0, 2, 50),
-			Error::<Test>::UnknownAsset
+			Error::<Test>::Unknown
 		);
 		// so we create it :)
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, true, 1));
@@ -185,7 +185,7 @@ fn transfer_approved_all_funds() {
 		// can't approve non-existent token
 		assert_noop!(
 			Assets::approve_transfer(RuntimeOrigin::signed(1), 0, 2, 50),
-			Error::<Test>::UnknownAsset
+			Error::<Test>::Unknown
 		);
 		// so we create it :)
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, true, 1));
@@ -788,7 +788,7 @@ fn set_metadata_should_work() {
 		// Cannot add metadata to unknown asset
 		assert_noop!(
 			Assets::set_metadata(RuntimeOrigin::signed(1), 0, vec![0u8; 10], vec![0u8; 10], 12),
-			Error::<Test>::UnknownAsset,
+			Error::<Test>::Unknown,
 		);
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), 0, 1, true, 1));
 		// Cannot add metadata to unowned asset
@@ -1094,7 +1094,7 @@ fn force_asset_status_should_work() {
 #[test]
 fn balance_conversion_should_work() {
 	new_test_ext().execute_with(|| {
-		use frame_support::traits::tokens::BalanceConversion;
+		use frame_support::traits::tokens::ConversionToAssetBalance;
 
 		let id = 42;
 		assert_ok!(Assets::force_create(RuntimeOrigin::root(), id, 1, true, 10));

--- a/pallets/rbac/src/mock.rs
+++ b/pallets/rbac/src/mock.rs
@@ -4,20 +4,16 @@ use frame_system as system;
 use frame_system::EnsureRoot;
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
 };
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
-  pub enum Test where
-	Block = Block,
-	NodeBlock = Block,
-	UncheckedExtrinsic = UncheckedExtrinsic,
+  pub enum Test
   {
-	System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+	System: frame_system::{Pallet, Call, Config<T>, Storage, Event<T>},
 	RBAC: pallet_rbac::{Pallet, Call, Storage, Event<T>},
   }
 );
@@ -34,13 +30,12 @@ impl system::Config for Test {
 	type DbWeight = ();
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
-	type Index = u64;
-	type BlockNumber = u64;
+	type Nonce = u64;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Block = Block;
 	type RuntimeEvent = RuntimeEvent;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
@@ -76,5 +71,5 @@ impl pallet_rbac::Config for Test {
 }
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
+	system::GenesisConfig::<Test>::default().build_storage().unwrap().into()
 }


### PR DESCRIPTION
- Mapped assets pallet DebitFlags struct is private to the crate, so the debitFlags parameter from the afloat_do_burn method was removed and the debitFlags created internally, finally updated the afloat pallet accordingly. 
- AssetId type is no longer Copy, so called the clone method where necessary. 
- CollectionId type is no longer Copy, so called the clone method where necessary. 
- JSON NumberValue struct has a new negative field, so this field was added as necesary. 
- GenesisBuild has been deprecated, so the BitcoinVaults and MappedAssets pallets to use the new BuildGenesisConfig trait. 
- Updated the block_number parameter type to be BlockNumberFor. 
- Added does_asset_exist method to the MappedAssets pallet. Updated the way of checking overflow in the MappedAssets pallet to use checked_add. Added back the Rbac type to the MappedAssets pallet.
- The where clause of the enum when contructing a mock runtime has been deprecated, so this clause was removed for all pallet mocks.
- Nonce and Block types have been added to the system::Config, and the Index, BlockNumber and Header types have been removed, so all pallet implementations for the Test runtime have been updated accordingly. 
- FreezeIdentifier, MaxFreezes, RuntimeHoldReason and MaxHolds types have been added for the balances pallet, so the test runtimes for pallets that use the balances pallet have been added accordingly.
- The GenesisConfig is now generic over the runtime, so the test build_storage for all pallets have been updated accordingly, also this is now behind the BuildStorage trait so it has been imported where required.
- The UnknownAsset error of the mapped assets pallet has been updated to be Unknown, so updated some of the tests accordingly. 
- The tokens BalanceConversion trait has been replaced by ConversionToAssetBalance, so updated the mapped assets test pallet accordingly.
