### PR TITLE
Out of bounds marketplace application

### DIFF
--- a/pallets/gated-marketplace/src/functions.rs
+++ b/pallets/gated-marketplace/src/functions.rs
@@ -135,8 +135,7 @@ impl<T: Config> Pallet<T> {
 		// ensure the origin is owner or admin
 		Self::is_authorized(authority.clone(), &marketplace_id, Permission::Enroll)?;
 
-		Self::validate_fields(&fields, &custodian_fields)?;
-		let (custodian, fields) = Self::set_up_application(fields, custodian_fields);
+		let (custodian, fields) = Self::set_up_application(fields, custodian_fields)?;
 
 		let application = Application::<T> {
 			status: ApplicationStatus::default(),
@@ -795,29 +794,12 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/* ---- Helper functions ---- */
-	pub fn validate_fields(
-		fields: &Fields<T>,
-		custodian_fields: &Option<CustodianFields<T>>,
-	) -> DispatchResult {
-		match custodian_fields {
-			Some(c_fields) => {
-				if fields.len() != c_fields.1.len() {
-					return Err(Error::<T>::InsufficientCustodianFields.into())
-				}
-			}
-			None => {
-				if fields.is_empty() {
-					return Err(Error::<T>::FieldsNotProvided.into())
-				}
-			}
-		}
-		Ok(())
-	}
-
 	pub fn set_up_application(
 		fields: Fields<T>,
 		custodian_fields: Option<CustodianFields<T>>,
-	) -> (Option<T::AccountId>, BoundedVec<ApplicationField, T::MaxFiles>) {
+	) -> Result<(Option<T::AccountId>, BoundedVec<ApplicationField, T::MaxFiles>), DispatchError> {	
+		ensure!(!fields.is_empty(), Error::<T>::FieldsNotProvided);
+
 		let mut f: Vec<ApplicationField> = fields
 			.iter()
 			.map(|tuple| ApplicationField {
@@ -826,8 +808,12 @@ impl<T: Config> Pallet<T> {
 				custodian_cid: None,
 			})
 			.collect();
+
 		let custodian = match custodian_fields {
 			Some(c_fields) => {
+				if fields.len() != c_fields.1.len() {
+					return Err(Error::<T>::InsufficientCustodianFields.into())
+				}
 				for (i, field) in f.iter_mut().enumerate() {
 					field.custodian_cid = Some(c_fields.1[i].clone());
 				}
@@ -835,7 +821,10 @@ impl<T: Config> Pallet<T> {
 			},
 			_ => None,
 		};
-		(custodian, BoundedVec::<ApplicationField, T::MaxFiles>::try_from(f).unwrap_or_default())
+
+		let fields = BoundedVec::<ApplicationField, T::MaxFiles>::try_from(f).
+			map_err(|_| Error::<T>::ExceedMaxFilesApplication)?;
+		Ok((custodian, fields))
 	}
 
 	fn insert_in_auth_market_lists(

--- a/pallets/gated-marketplace/src/functions.rs
+++ b/pallets/gated-marketplace/src/functions.rs
@@ -806,7 +806,7 @@ impl<T: Config> Pallet<T> {
 				}
 			}
 			None => {
-				if !fields.is_empty() {
+				if fields.is_empty() {
 					return Err(Error::<T>::FieldsNotProvided.into())
 				}
 			}

--- a/pallets/gated-marketplace/src/lib.rs
+++ b/pallets/gated-marketplace/src/lib.rs
@@ -338,6 +338,10 @@ pub mod pallet {
 		OwnerNotInMarketplace,
 		/// MappedAssetId not found
 		AssetNotFound,
+		/// Not enough custodian fields provided
+		InsufficientCustodianFields,
+		/// Fields not provided for the application
+		FieldsNotProvided
 	}
 
 	#[pallet::call]
@@ -435,6 +439,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
+			Self::validate_fields(&fields, &custodian_fields)?;
 			let (custodian, fields) = Self::set_up_application(fields, custodian_fields);
 
 			let application = Application::<T> {
@@ -473,6 +478,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
+			Self::validate_fields(&fields, &custodian_fields)?;
 			let (custodian, fields) = Self::set_up_application(fields, custodian_fields);
 
 			let application = Application::<T> {

--- a/pallets/gated-marketplace/src/lib.rs
+++ b/pallets/gated-marketplace/src/lib.rs
@@ -341,7 +341,9 @@ pub mod pallet {
 		/// Not enough custodian fields provided
 		InsufficientCustodianFields,
 		/// Fields not provided for the application
-		FieldsNotProvided
+		FieldsNotProvided,
+		/// Exceeds the maximum number of files
+		ExceedMaxFilesApplication,
 	}
 
 	#[pallet::call]
@@ -439,8 +441,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
-			Self::validate_fields(&fields, &custodian_fields)?;
-			let (custodian, fields) = Self::set_up_application(fields, custodian_fields);
+			let (custodian, fields) = Self::set_up_application(fields, custodian_fields)?;
 
 			let application = Application::<T> {
 				status: ApplicationStatus::default(),
@@ -478,8 +479,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
-			Self::validate_fields(&fields, &custodian_fields)?;
-			let (custodian, fields) = Self::set_up_application(fields, custodian_fields);
+			let (custodian, fields) = Self::set_up_application(fields, custodian_fields)?;
 
 			let application = Application::<T> {
 				status: ApplicationStatus::default(),

--- a/pallets/gated-marketplace/src/mock.rs
+++ b/pallets/gated-marketplace/src/mock.rs
@@ -163,16 +163,17 @@ impl pallet_balances::Config for Test {
 }
 
 parameter_types! {
-  pub const MaxScopesPerPallet: u32 = 2;
-  pub const MaxRolesPerPallet: u32 = 6;
-  pub const RoleMaxLen: u32 = 25;
-  pub const PermissionMaxLen: u32 = 25;
-  pub const MaxPermissionsPerRole: u32 = 30;
-  pub const MaxRolesPerUser: u32 = 2;
-  pub const MaxUsersPerRole: u32 = 2;
+	pub const MaxScopesPerPallet: u32 = 2;
+	pub const MaxRolesPerPallet: u32 = 6;
+	pub const RoleMaxLen: u32 = 25;
+	pub const PermissionMaxLen: u32 = 25;
+	pub const MaxPermissionsPerRole: u32 = 30;
+	pub const MaxRolesPerUser: u32 = 2;
+	pub const MaxUsersPerRole: u32 = 2;
 }
 impl pallet_rbac::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
+	type RemoveOrigin = EnsureRoot<Self::AccountId>;
 	type MaxScopesPerPallet = MaxScopesPerPallet;
 	type MaxRolesPerPallet = MaxRolesPerPallet;
 	type RoleMaxLen = RoleMaxLen;
@@ -180,7 +181,7 @@ impl pallet_rbac::Config for Test {
 	type MaxPermissionsPerRole = MaxPermissionsPerRole;
 	type MaxRolesPerUser = MaxRolesPerUser;
 	type MaxUsersPerRole = MaxUsersPerRole;
-	type RemoveOrigin = EnsureRoot<Self::AccountId>;
+	type WeightInfo = ();
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/gated-marketplace/src/mock.rs
+++ b/pallets/gated-marketplace/src/mock.rs
@@ -1,5 +1,4 @@
 use crate as pallet_gated_marketplace;
-use frame_system::RawOrigin;
 use sp_runtime::traits::Lookup;
 
 use frame_support::{
@@ -22,6 +21,7 @@ use sp_runtime::{
 use system::EnsureSigned;
 type AccountId = u64;
 type AssetId = u32;
+
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
   pub enum Test

--- a/pallets/gated-marketplace/src/tests.rs
+++ b/pallets/gated-marketplace/src/tests.rs
@@ -274,6 +274,60 @@ fn apply_with_custodian_works() {
 }
 
 #[test]
+fn apply_with_mismatched_number_of_files_and_custodian_files_shouldnt_work() {
+	new_test_ext().execute_with(|| {
+		Balances::make_free_balance_be(&1, 100);
+		// Dispatch a signed extrinsic.
+		let m_label = create_label("my marketplace");
+		assert_ok!(GatedMarketplace::create_marketplace(
+			RuntimeOrigin::signed(1),
+			2,
+			m_label.clone(),
+			500,
+			600,
+			1,
+		));
+		let m_id = get_marketplace_id("my marketplace", 500, 600, 1);
+		assert_noop!(
+			GatedMarketplace::apply(
+				RuntimeOrigin::signed(3),
+				m_id,
+				create_application_fields(2),
+				create_custodian_fields(4, 1)
+			),
+			Error::<Test>::InsufficientCustodianFields
+		);
+	});
+}
+
+#[test]
+fn apply_with_custodian_but_no_custodian_files_shouldnt_work() {
+	new_test_ext().execute_with(|| {
+		Balances::make_free_balance_be(&1, 100);
+		// Dispatch a signed extrinsic.
+		let m_label = create_label("my marketplace");
+		assert_ok!(GatedMarketplace::create_marketplace(
+			RuntimeOrigin::signed(1),
+			2,
+			m_label.clone(),
+			500,
+			600,
+			1,
+		));
+		let m_id = get_marketplace_id("my marketplace", 500, 600, 1);
+		assert_noop!(
+			GatedMarketplace::apply(
+				RuntimeOrigin::signed(3),
+				m_id,
+				create_application_fields(2),
+				create_custodian_fields(4, 0)
+			),
+			Error::<Test>::InsufficientCustodianFields
+		);
+	});
+}
+
+#[test]
 fn apply_with_same_account_as_custodian_shouldnt_work() {
 	new_test_ext().execute_with(|| {
 		Balances::make_free_balance_be(&1, 100);
@@ -378,7 +432,7 @@ fn apply_twice_shouldnt_work() {
 			1,
 		));
 		let m_id = get_marketplace_id("my marketplace", 500, 600, 1);
-		
+
 		assert_ok!(GatedMarketplace::apply(
 			RuntimeOrigin::signed(3),
 			m_id,

--- a/pallets/gated-marketplace/src/tests.rs
+++ b/pallets/gated-marketplace/src/tests.rs
@@ -301,7 +301,7 @@ fn apply_with_custodian_works() {
 }
 
 #[test]
-fn apply_with_mismatched_number_of_files_and_custodian_files_shouldnt_work() {
+fn apply_with_mismatched_number_of_fields_and_custodian_fields_shouldnt_work() {
 	new_test_ext().execute_with(|| {
 		Balances::make_free_balance_be(&1, 100);
 		// Dispatch a signed extrinsic.

--- a/pallets/gated-marketplace/src/tests.rs
+++ b/pallets/gated-marketplace/src/tests.rs
@@ -245,6 +245,33 @@ fn apply_to_marketplace_works() {
 }
 
 #[test]
+fn apply_to_marketplace_without_fields_shouldnt_work() {
+	new_test_ext().execute_with(|| {
+		Balances::make_free_balance_be(&1, 100);
+		// Dispatch a signed extrinsic.
+		let m_label = create_label("my marketplace");
+		assert_ok!(GatedMarketplace::create_marketplace(
+			RuntimeOrigin::signed(1),
+			2,
+			m_label.clone(),
+			500,
+			600,
+			1,
+		));
+		let m_id = get_marketplace_id("my marketplace", 500, 600, 1);
+		assert_noop!(
+			GatedMarketplace::apply(
+				RuntimeOrigin::signed(3),
+				m_id,
+				create_application_fields(0),
+				None
+			),
+			Error::<Test>::FieldsNotProvided
+		);
+	});
+}
+
+#[test]
 fn apply_with_custodian_works() {
 	new_test_ext().execute_with(|| {
 		Balances::make_free_balance_be(&1, 100);

--- a/pallets/gated-marketplace/src/tests.rs
+++ b/pallets/gated-marketplace/src/tests.rs
@@ -328,7 +328,7 @@ fn apply_with_mismatched_number_of_files_and_custodian_files_shouldnt_work() {
 }
 
 #[test]
-fn apply_with_custodian_but_no_custodian_files_shouldnt_work() {
+fn apply_with_custodian_but_no_custodian_fields_shouldnt_work() {
 	new_test_ext().execute_with(|| {
 		Balances::make_free_balance_be(&1, 100);
 		// Dispatch a signed extrinsic.

--- a/pallets/gated-marketplace/src/tests.rs
+++ b/pallets/gated-marketplace/src/tests.rs
@@ -378,6 +378,7 @@ fn apply_twice_shouldnt_work() {
 			1,
 		));
 		let m_id = get_marketplace_id("my marketplace", 500, 600, 1);
+		
 		assert_ok!(GatedMarketplace::apply(
 			RuntimeOrigin::signed(3),
 			m_id,


### PR DESCRIPTION
# Validation Fixes and Tests in Gated Marketplace

## Overview

The changes implemented focus on enhancing the gated marketplace pallet by introducing error handling for application setup and enforcing validation checks. The motivation behind these changes is to ensure that applications to the marketplace meet specific criteria, such as having the required fields and adhering to the constraints for custodian relationships. This improvement in validation prevents potential runtime errors and enhances the overall robustness of the marketplace application process.

### Tickets

- [ ] Fix #29

## Implementation notes

The implementation involves modifying the `set_up_application` function to return a `Result` type, enabling the function to handle errors gracefully by leveraging Rust's error handling paradigm. Additional checks are introduced to ensure that:
- The `fields` provided for an application are not empty.
- The number of custodian fields matches the number of application fields when custodians are involved.
- The maximum number of files specified for an application is not exceeded.

These checks are accomplished using the `ensure!` macro for concise assertions and the `.map_err` method to transform errors from the `try_from` method into pallet-specific errors.

Furthermore, corresponding changes are made in the callers of `set_up_application` within the module to handle the `Result` returned by the

## Interesting/controversial decisions

The decision to enforce strict validation at the application setup stage could be seen as restrictive, especially in scenarios where marketplace dynamics might demand more flexibility.

## Test coverage

New tests were added in `tests.rs` to cover scenarios involving the new validations. These include tests for applying without fields, applying with mismatched numbers of fields and custodian fields, and exceeding the maximum allowed fields. The tests verify that the system correctly rejects invalid or incomplete applications, and they help ensure that the validations work as intended.